### PR TITLE
disable cgo, remove c stdlib from run requirements

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
 cdt_name:
 - conda
 channel_sources:
@@ -10,7 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-go_compiler:
-- go-nocgo
 target_platform:
 - linux-64

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
 cdt_name:
 - conda
 channel_sources:
@@ -10,7 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-go_compiler:
-- go-nocgo
 target_platform:
 - linux-aarch64

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
 cdt_name:
 - conda
 channel_sources:
@@ -10,7 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-go_compiler:
-- go-nocgo
 target_platform:
 - linux-ppc64le

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -2,16 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
-c_stdlib:
-- macosx_deployment_target
-c_stdlib_version:
-- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-go_compiler:
-- go-nocgo
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -2,16 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-c_stdlib:
-- macosx_deployment_target
-c_stdlib_version:
-- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-go_compiler:
-- go-nocgo
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,10 +1,6 @@
-c_stdlib:
-- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-go_compiler:
-- go-nocgo
 target_platform:
 - win-64

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -37,6 +37,9 @@ move /y pixi.toml pixi.toml.bak
 set "arch=64"
 if "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "arch=arm64"
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "(Get-Content pixi.toml.bak -Encoding UTF8) -replace 'platforms = .*', 'platforms = [''win-%arch%'']' | Out-File pixi.toml -Encoding UTF8"
+:: Git on Windows needs to run post link scripts to properly set up SSL certificates
+pixi config set --global run-post-link-scripts insecure
+if !errorlevel! neq 0 exit /b !errorlevel!
 pixi install
 if !errorlevel! neq 0 exit /b !errorlevel!
 pixi list

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "go-task-feedstock"
-version = "3.47.2"  # conda-smithy version used to generate this file
+version = "3.50.0"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/go-task-feedstock"
 authors = ["@conda-forge/go-task"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -24,9 +24,8 @@ build:
 
 requirements:
   build:
-    - ${{ compiler('go') }}
+    - ${{ compiler('go-nocgo') }}
     - ${{ stdlib('c') }}
-    - go-nocgo
     - go-licenses
 
 tests:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
     sha256: a8ee62d92b654bec1fe22522f1a9a2d51386d9d7508bec164080083e28e99b2c
 
 build:
-  number: 0
+  number: 1
   script:
     - pushd "${{ pkg_src }}"
     - if: win
@@ -25,7 +25,6 @@ build:
 requirements:
   build:
     - ${{ compiler('go-nocgo') }}
-    - ${{ stdlib('c') }}
     - go-licenses
 
 tests:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


we didn't get the right compiler, we still have a `__glibc` as run requirements if we use `${{ compiler('go') }}`