### PR TITLE
Add pixi global-ignore-conda-prefix marker to prevent CONDA_PREFIX leakage

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -20,6 +20,7 @@ build:
     - if: win
       then: go install -v -ldflags="-w -s -X main.version=conda-forge" ./cmd/task
       else: go build -v -ldflags="-w -s -X main.version=conda-forge" -o $PREFIX/bin/task ./cmd/task
+    - go-licenses save "." --save_path "library_licenses" --ignore github.com/go-task/template
     # Pixi: prevent CONDA_PREFIX from leaking into sandboxed processes
     - if: win
       then:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,13 +14,21 @@ source:
     sha256: ee12bd4bd445df59de17d9b4376f8afb6a623facce34169479af8b0569220034
 
 build:
-  number: 0
+  number: 1
   script:
     - pushd "${{ pkg_src }}"
     - if: win
       then: go install -v -ldflags="-w -s -X main.version=conda-forge" ./cmd/task
       else: go build -v -ldflags="-w -s -X main.version=conda-forge" -o $PREFIX/bin/task ./cmd/task
     - go-licenses save "." --save_path "library_licenses" --ignore github.com/go-task/template
+    # Pixi: prevent CONDA_PREFIX from leaking into sandboxed processes
+    - if: win
+      then:
+        - mkdir "%PREFIX%\etc\pixi\go-task"
+        - type nul > "%PREFIX%\etc\pixi\go-task\global-ignore-conda-prefix"
+      else:
+        - mkdir -p ${PREFIX}/etc/pixi/go-task
+        - touch ${PREFIX}/etc/pixi/go-task/global-ignore-conda-prefix
 
 requirements:
   build:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -24,8 +24,8 @@ build:
     # Pixi: prevent CONDA_PREFIX from leaking into sandboxed processes
     - if: win
       then:
-        - mkdir "%PREFIX%\etc\pixi\go-task"
-        - type nul > "%PREFIX%\etc\pixi\go-task\global-ignore-conda-prefix"
+        - 'mkdir "%PREFIX%\etc\pixi\go-task"'
+        - 'type nul > "%PREFIX%\etc\pixi\go-task\global-ignore-conda-prefix"'
       else:
         - mkdir -p ${PREFIX}/etc/pixi/go-task
         - touch ${PREFIX}/etc/pixi/go-task/global-ignore-conda-prefix

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -20,7 +20,7 @@ build:
     - if: win
       then: go install -v -ldflags="-w -s -X main.version=conda-forge" ./cmd/task
       else: go build -v -ldflags="-w -s -X main.version=conda-forge" -o $PREFIX/bin/task ./cmd/task
-    - go-licenses save "." --save_path "library_licenses" --ignore github.com/go-task/template
+    - go-licenses save "." --save_path "library_licenses" --ignore github.com/go-task/template --ignore github.com/alecthomas/chroma/v2
     # Pixi: prevent CONDA_PREFIX from leaking into sandboxed processes
     - if: win
       then:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,7 +21,7 @@ build:
       then: go install -v -ldflags="-w -s -X main.version=conda-forge" ./cmd/task
       else: go build -v -ldflags="-w -s -X main.version=conda-forge" -o $PREFIX/bin/task ./cmd/task
     - go-licenses save "." --save_path "library_licenses" --ignore github.com/go-task/template --ignore github.com/alecthomas/chroma/v2
-    # Pixi: prevent CONDA_PREFIX from leaking into sandboxed processes
+    # Pixi: prevent CONDA_PREFIX from leaking into task command
     - if: win
       then:
         - 'mkdir "%PREFIX%\etc\pixi\go-task"'


### PR DESCRIPTION
Fixes #18

## Problem

`go-task` inherits `CONDA_PREFIX` from conda/pixi environments and passes it to child processes, leaking conda environment variables.

## Solution

Following the [Pixi packaging guidelines](https://pixi.prefix.dev/latest/global_tools/introduction/#packaging), this adds a marker file at `etc/pixi/go-task/global-ignore-conda-prefix` which tells Pixi to strip `CONDA_PREFIX` when running go-task.

## Changes

- Bumped build number to 1
- Added `mkdir -p ${PREFIX}/etc/pixi/go-task` and `touch ${PREFIX}/etc/pixi/go-task/global-ignore-conda-prefix` to the build script (Unix only)